### PR TITLE
Agregar página web para charla de thin

### DIFF
--- a/public/workshop/_data.json
+++ b/public/workshop/_data.json
@@ -126,7 +126,7 @@
   }, 
   "thin": {
     "titulo": "Thin Languages", 
-    "abstract": "En el desarrollo de software hay grandes coincidencias en las nociones conceptuales de los lenguajes de programación y sus construcciones semánticas que los lenguajes deberían tener mientras que los principales puntos de discrepancia están en los detalles sintácticos y cuestiones de forma. Thin Languages es un proyecto en el que se mantiene un modelo semántico y se lo puede traducir a cualquier sintaxis soportada por el motor del proyecto, llamado less. El hecho de mantener el modelo semántico apunta a preservar la idea sin estar atado a una sintaxis en particular y hace que pueda compilarse a múltiples plataformas. Además permite personalizar convenciones en sintaxis como tabulaciones, espacios y otras más.",
+    "abstract": "En el desarrollo de software hay grandes coincidencias en las nociones conceptuales de los lenguajes de programación y sus construcciones semánticas que los lenguajes deberían tener mientras que los principales puntos de discrepancia están en los detalles sintácticos y cuestiones de forma. Thin Languages es un proyecto en el que se mantiene un modelo semántico y se lo puede traducir a cualquier sintaxis soportada por el motor del proyecto, llamado less. El hecho de mantener el modelo semántico apunta a preservar la idea sin estar atado a una sintaxis en particular y hace que pueda compilarse a múltiples plataformas. Además permite personalizar convenciones en sintaxis como tabulaciones, espacios y otras más",
     "oradores": [
       {
         "nombre" : "Nicolás Scarcella",
@@ -136,7 +136,8 @@
         "nombre": "Ernesto Bossi",
         "bio": "Docente de Técnicas Avanzadas de Programación, Arquitecturas Concurrentes y Sistemas Mainframes en UTN-FRBA. Programador trabajando en Deviget LLC y otros proyectos locos."
       }
-    ]
+    ],
+    "page" : "http://uqbar-project.github.io/java-less/"
   },   
   "wollok": {
     "titulo": "Repensando la enseñanza de POO: Wollok en el aula y más allá",

--- a/public/workshop/index.jade
+++ b/public/workshop/index.jade
@@ -76,9 +76,13 @@ block content
                 p.nombre #{orador.nombre}
                 p.bio #{orador.bio}
 
-
           if taller.extra 
             .orador
               p.nombre #{taller.extra.nombre}
               p.bio #{taller.extra.bio}
+
+          if taller.page
+            p.destacadito Página Web
+            a
+              p.page #{taller.page}
   


### PR DESCRIPTION
Me gustaría agregar como adicional el link de la página de proyecto de thin ya que mucha gente le interesó y no pudieron ver la página web oficial. Adicionalmente creo que estaría bueno después que haya una sección de preceedings con las ppts y páginas de los proyectos como para referencias futuras.

Gracias
